### PR TITLE
Add scope 'moderation:ban'

### DIFF
--- a/scope_enum.go
+++ b/scope_enum.go
@@ -11,6 +11,7 @@ const (
 	ScopeChatWrite                   // chat:write
 	ScopeStremkeyRead                // streamkey:read
 	ScopeEventSubscribe              // events:subscribe
+	ScopeModerationBan               // moderation:ban
 )
 
 func NewScope(scope string) (Scope, error) {
@@ -27,6 +28,8 @@ func NewScope(scope string) (Scope, error) {
 		return ScopeStremkeyRead, nil
 	case "events:subscribe":
 		return ScopeEventSubscribe, nil
+	case "moderation:ban":
+		return ScopeModerationBan, nil
 	default:
 		return 0, fmt.Errorf("unknown scope: %s", scope)
 	}
@@ -46,6 +49,8 @@ func (s Scope) String() string {
 		return "streamkey:read"
 	case ScopeEventSubscribe:
 		return "events:subscribe"
+	case ScopeModerationBan:
+		return "moderation:ban"
 	default:
 		return "unknown"
 	}

--- a/scope_enum_test.go
+++ b/scope_enum_test.go
@@ -31,6 +31,7 @@ func TestNewScopeSuccess(t *testing.T) {
 		"chat:write":       gokick.ScopeChatWrite,
 		"streamkey:read":   gokick.ScopeStremkeyRead,
 		"events:subscribe": gokick.ScopeEventSubscribe,
+		"moderation:ban":   gokick.ScopeModerationBan,
 	}
 
 	for name, value := range testCases {


### PR DESCRIPTION
Not sure if this is necessary, but the scope is mentioned in the official docs:

<img width="1608" height="1708" alt="Screenshot from 2025-07-13 18-58-43" src="https://github.com/user-attachments/assets/f111e9bb-5cd9-4452-b652-8eb1a95bbae6" />

So adding for completeness.